### PR TITLE
Fix scroll on mobile when expense sheet is open

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,15 @@ export default function App() {
     saveProjects(projects);
   }, [projects]);
 
+  useEffect(() => {
+    if (showCreateExpense || editingExpense) {
+      document.body.classList.add('sheet-open');
+    } else {
+      document.body.classList.remove('sheet-open');
+    }
+    return () => document.body.classList.remove('sheet-open');
+  }, [showCreateExpense, editingExpense]);
+
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
 
   function updateProject(id, updater) {


### PR DESCRIPTION
## Summary
- Add useEffect to toggle \`sheet-open\` class on body when expense creation/update sheet opens
- Fixes issue #2: scroll was broken on mobile - the content behind the sheet could still be scrolled

## Changes
- \`src/App.jsx\`: Added useEffect to manage body scroll lock via CSS class \`sheet-open\`

## Testing
- Verified build passes
- Manual testing on mobile shows sheet overlay now properly blocks background scroll