### PR TITLE
Add personal projects feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,14 @@ import ActivityLog from './components/ActivityLog.jsx';
 import CreateExpenseSheet from './components/CreateExpenseSheet.jsx';
 import ExpenseList from './components/ExpenseList.jsx';
 import PersonSummary from './components/PersonSummary.jsx';
-import { formatCOP, getExpenseTotal, haptic, loadProjects, saveProjects } from './utils.js';
+import {
+  formatCOP,
+  getExpenseTotal,
+  haptic,
+  loadProjects,
+  PROJECT_TYPES,
+  saveProjects,
+} from './utils.js';
 
 export default function App() {
   const [projects, setProjects] = useState(() => loadProjects());
@@ -13,6 +20,7 @@ export default function App() {
   const [editingExpense, setEditingExpense] = useState(null);
   const [showCreateProject, setShowCreateProject] = useState(false);
   const [newProjectName, setNewProjectName] = useState('');
+  const [newProjectType, setNewProjectType] = useState(PROJECT_TYPES.SHARED);
   const [viewState, setViewState] = useState('idle');
 
   useEffect(() => {
@@ -65,12 +73,14 @@ export default function App() {
     const project = {
       id: crypto.randomUUID(),
       name,
+      type: newProjectType,
       expenses: [],
       logs: [],
       createdAt: new Date().toISOString(),
     };
     setProjects((ps) => [...ps, project]);
     setNewProjectName('');
+    setNewProjectType(PROJECT_TYPES.SHARED);
     setShowCreateProject(false);
     navigateTo(project.id);
   }
@@ -176,14 +186,39 @@ export default function App() {
             value={newProjectName}
             onChange={(e) => setNewProjectName(e.target.value)}
             placeholder="Ej: Viaje, Casa, Oficina"
-            className="w-full bg-[var(--input-bg)] border border-[var(--input-border)] rounded-xl px-4 py-3 text-[16px] text-[var(--color-text)] placeholder:text-[var(--color-text-ghost)] mb-3"
+            className="w-full bg-[var(--input-bg)] border border-[var(--input-border)] rounded-xl px-4 py-3 text-[16px] text-[var(--color-text)] placeholder:text-[var(--color-text-ghost)] mb-4"
           />
+          <div className="flex gap-2 mb-4">
+            <button
+              type="button"
+              onClick={() => setNewProjectType(PROJECT_TYPES.SHARED)}
+              className={`flex-1 py-3 rounded-xl text-[14px] font-semibold transition-colors ${
+                newProjectType === PROJECT_TYPES.SHARED
+                  ? 'bg-[var(--color-teal)] text-white'
+                  : 'bg-[var(--input-bg)] border border-[var(--input-border)] text-[var(--color-text-dim)]'
+              }`}
+            >
+              Compartido
+            </button>
+            <button
+              type="button"
+              onClick={() => setNewProjectType(PROJECT_TYPES.PERSONAL)}
+              className={`flex-1 py-3 rounded-xl text-[14px] font-semibold transition-colors ${
+                newProjectType === PROJECT_TYPES.PERSONAL
+                  ? 'bg-[var(--color-teal)] text-white'
+                  : 'bg-[var(--input-bg)] border border-[var(--input-border)] text-[var(--color-text-dim)]'
+              }`}
+            >
+              Personal
+            </button>
+          </div>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={() => {
                 setShowCreateProject(false);
                 setNewProjectName('');
+                setNewProjectType(PROJECT_TYPES.SHARED);
               }}
               className="flex-1 py-2.5 rounded-xl text-[14px] font-semibold bg-[var(--cancel-bg)] border border-[var(--cancel-border)] text-[var(--cancel-color)]"
             >
@@ -267,6 +302,11 @@ export default function App() {
                 {activeProject.expenses.length} gasto
                 {activeProject.expenses.length !== 1 ? 's' : ''}
               </span>
+              {activeProject.type === 'personal' && (
+                <span className="ml-2 text-[10px] font-bold bg-[var(--stat-bg)] border border-[var(--stat-border)] text-[var(--color-teal-dark)] px-2 py-0.5 rounded-full uppercase tracking-wide">
+                  Personal
+                </span>
+              )}
             </div>
             <button
               type="button"
@@ -290,7 +330,7 @@ export default function App() {
         <div className="max-w-[640px] mx-auto pt-safe-top px-4 pb-safe-fab">
           {activeProject ? (
             <>
-              <PersonSummary expenses={activeProject.expenses} />
+              <PersonSummary expenses={activeProject.expenses} projectType={activeProject.type} />
 
               {activeProject.expenses.length === 0 ? (
                 <div className="text-center py-8">
@@ -302,6 +342,7 @@ export default function App() {
               ) : (
                 <ExpenseList
                   expenses={activeProject.expenses}
+                  projectType={activeProject.type}
                   onToggle={toggleExpenseStatus}
                   onDelete={deleteExpense}
                   onEdit={setEditingExpense}
@@ -348,6 +389,7 @@ export default function App() {
             setEditingExpense(null);
           }}
           expense={editingExpense}
+          projectType={activeProject.type}
           people={[...new Set(activeProject.expenses.map((e) => e.person).filter(Boolean))]}
         />
       )}

--- a/src/components/CreateExpenseSheet.jsx
+++ b/src/components/CreateExpenseSheet.jsx
@@ -3,7 +3,8 @@ import { useState } from 'react';
 import { formatCOP } from '../utils.js';
 import Tabs from './Tabs.jsx';
 
-export default function CreateExpenseSheet({ onSave, onClose, expense, people }) {
+export default function CreateExpenseSheet({ onSave, onClose, expense, people, projectType }) {
+  const isPersonal = projectType === 'personal';
   const isEdit = !!expense;
   const [description, setDescription] = useState(expense?.description ?? '');
   const [person, setPerson] = useState(expense?.person ?? '');
@@ -49,7 +50,7 @@ export default function CreateExpenseSheet({ onSave, onClose, expense, people })
   }
 
   function handleSave() {
-    if (!description.trim() || !person.trim()) return;
+    if (!description.trim() || (!isPersonal && !person.trim())) return;
 
     let saveData;
     if (isStacked) {
@@ -57,7 +58,7 @@ export default function CreateExpenseSheet({ onSave, onClose, expense, people })
       if (validItems.length === 0) return;
       saveData = {
         description: description.trim(),
-        person: person.trim(),
+        person: isPersonal ? 'Yo' : person.trim(),
         date,
         status,
         note: note.trim(),
@@ -72,7 +73,7 @@ export default function CreateExpenseSheet({ onSave, onClose, expense, people })
       if (!singleAmount || amount < 1) return;
       saveData = {
         description: description.trim(),
-        person: person.trim(),
+        person: isPersonal ? 'Yo' : person.trim(),
         date,
         status,
         note: note.trim(),
@@ -144,30 +145,32 @@ export default function CreateExpenseSheet({ onSave, onClose, expense, people })
             />
           </div>
 
-          <div>
-            <label
-              htmlFor="expense-person"
-              className="text-[13px] font-semibold text-[var(--color-text-muted)] mb-1 block"
-            >
-              Persona
-            </label>
-            <input
-              id="expense-person"
-              type="text"
-              value={person}
-              onChange={(e) => setPerson(e.target.value)}
-              placeholder="Ej: Carlos"
-              list="people-suggestions"
-              className="w-full bg-[var(--input-bg)] border border-[var(--input-border)] rounded-xl px-4 py-3 text-[16px] text-[var(--color-text)] placeholder:text-[var(--color-text-ghost)]"
-            />
-            {people?.length > 0 && (
-              <datalist id="people-suggestions">
-                {people.map((p) => (
-                  <option key={p} value={p} />
-                ))}
-              </datalist>
-            )}
-          </div>
+          {!isPersonal && (
+            <div>
+              <label
+                htmlFor="expense-person"
+                className="text-[13px] font-semibold text-[var(--color-text-muted)] mb-1 block"
+              >
+                Persona
+              </label>
+              <input
+                id="expense-person"
+                type="text"
+                value={person}
+                onChange={(e) => setPerson(e.target.value)}
+                placeholder="Ej: Carlos"
+                list="people-suggestions"
+                className="w-full bg-[var(--input-bg)] border border-[var(--input-border)] rounded-xl px-4 py-3 text-[16px] text-[var(--color-text)] placeholder:text-[var(--color-text-ghost)]"
+              />
+              {people?.length > 0 && (
+                <datalist id="people-suggestions">
+                  {people.map((p) => (
+                    <option key={p} value={p} />
+                  ))}
+                </datalist>
+              )}
+            </div>
+          )}
 
           <div className="flex gap-3">
             <div className="flex-1">
@@ -323,7 +326,7 @@ export default function CreateExpenseSheet({ onSave, onClose, expense, people })
           onClick={handleSave}
           disabled={
             !description.trim() ||
-            !person.trim() ||
+            (!isPersonal && !person.trim()) ||
             (!isStacked
               ? !singleAmount || Number(singleAmount) < 1
               : items.filter((i) => i.description.trim() && i.amount).length === 0)

--- a/src/components/ExpenseCard.jsx
+++ b/src/components/ExpenseCard.jsx
@@ -2,10 +2,11 @@ import { CheckCircle, ChevronDown, ChevronRight, Clock, Pencil, Trash2 } from 'l
 import { useState } from 'react';
 import { formatCOP, getExpenseTotal } from '../utils.js';
 
-export default function ExpenseCard({ expense, onToggle, onDelete, onEdit }) {
+export default function ExpenseCard({ expense, projectType, onToggle, onDelete, onEdit }) {
   const [expanded, setExpanded] = useState(false);
   const isPaid = expense.status === 'paid';
   const hasItems = expense.items && expense.items.length > 1;
+  const isPersonal = projectType === 'personal';
 
   return (
     <div className="bg-[var(--card-bg)] border border-[var(--card-border)] rounded-[16px] p-4 mb-3 transition-all">
@@ -14,7 +15,9 @@ export default function ExpenseCard({ expense, onToggle, onDelete, onEdit }) {
           <p className="font-bold text-[15px] text-[var(--color-text)] leading-[1.3]">
             {expense.description}
           </p>
-          <p className="text-[13px] text-[var(--color-text-faint)] mt-0.5">{expense.person}</p>
+          {!isPersonal && (
+            <p className="text-[13px] text-[var(--color-text-faint)] mt-0.5">{expense.person}</p>
+          )}
         </div>
         <div className="flex items-center gap-2 shrink-0 ml-3">
           <span className="font-extrabold text-[16px] text-[var(--color-teal-dark)]">

--- a/src/components/ExpenseList.jsx
+++ b/src/components/ExpenseList.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import ExpenseCard from './ExpenseCard.jsx';
 import ExpenseTable from './ExpenseTable.jsx';
 
-export default function ExpenseList({ expenses, onToggle, onDelete, onEdit }) {
+export default function ExpenseList({ expenses, projectType, onToggle, onDelete, onEdit }) {
   const [isDesktop, setIsDesktop] = useState(
     () => typeof window !== 'undefined' && window.innerWidth >= 640
   );
@@ -17,7 +17,13 @@ export default function ExpenseList({ expenses, onToggle, onDelete, onEdit }) {
 
   if (isDesktop) {
     return (
-      <ExpenseTable expenses={sorted} onToggle={onToggle} onDelete={onDelete} onEdit={onEdit} />
+      <ExpenseTable
+        expenses={sorted}
+        projectType={projectType}
+        onToggle={onToggle}
+        onDelete={onDelete}
+        onEdit={onEdit}
+      />
     );
   }
 
@@ -27,6 +33,7 @@ export default function ExpenseList({ expenses, onToggle, onDelete, onEdit }) {
         <ExpenseCard
           key={expense.id}
           expense={expense}
+          projectType={projectType}
           onToggle={onToggle}
           onDelete={onDelete}
           onEdit={onEdit}

--- a/src/components/ExpenseTable.jsx
+++ b/src/components/ExpenseTable.jsx
@@ -19,111 +19,119 @@ import { formatCOP, getExpenseTotal } from '../utils.js';
 
 const columnHelper = createColumnHelper();
 
-const columns = [
-  columnHelper.display({
-    id: 'expand',
-    header: () => null,
-    cell: ({ row, table }) => {
-      const { expanded, onToggleExpand } = table.options.meta;
-      const hasItems = row.original.items && row.original.items.length > 1;
-      if (!hasItems) return <div className="w-6" />;
-      const isExpanded = !!expanded[row.original.id];
-      return (
-        <button
-          type="button"
-          onClick={() => onToggleExpand(row.original.id)}
-          className="p-1 rounded hover:bg-[var(--card-bg)] transition-colors"
-        >
-          {isExpanded ? (
-            <ChevronDown size={16} className="text-[var(--color-text-muted)]" />
-          ) : (
-            <ChevronRight size={16} className="text-[var(--color-text-muted)]" />
-          )}
-        </button>
-      );
-    },
-  }),
-  columnHelper.accessor('description', {
-    header: 'Descripción',
-    cell: (info) => <span className="font-bold text-[15px]">{info.getValue()}</span>,
-  }),
-  columnHelper.accessor('person', {
-    header: 'Persona',
-    cell: (info) => (
-      <span className="text-[13px] text-[var(--color-text-faint)]">{info.getValue()}</span>
-    ),
-  }),
-  columnHelper.accessor((row) => getExpenseTotal(row), {
-    id: 'amount',
-    header: 'Monto',
-    cell: (info) => (
-      <div className="flex items-center gap-2">
-        <span className="font-extrabold text-[16px] text-[var(--color-teal-dark)]">
-          {formatCOP(info.getValue())}
-        </span>
-        {info.row.original.items && info.row.original.items.length > 1 && (
-          <span className="text-[11px] text-[var(--color-text-muted)]">
-            ({info.row.original.items.length} ítems)
+function buildColumns(isPersonal) {
+  return [
+    columnHelper.display({
+      id: 'expand',
+      header: () => null,
+      cell: ({ row, table }) => {
+        const { expanded, onToggleExpand } = table.options.meta;
+        const hasItems = row.original.items && row.original.items.length > 1;
+        if (!hasItems) return <div className="w-6" />;
+        const isExpanded = !!expanded[row.original.id];
+        return (
+          <button
+            type="button"
+            onClick={() => onToggleExpand(row.original.id)}
+            className="p-1 rounded hover:bg-[var(--card-bg)] transition-colors"
+          >
+            {isExpanded ? (
+              <ChevronDown size={16} className="text-[var(--color-text-muted)]" />
+            ) : (
+              <ChevronRight size={16} className="text-[var(--color-text-muted)]" />
+            )}
+          </button>
+        );
+      },
+    }),
+    columnHelper.accessor('description', {
+      header: 'Descripción',
+      cell: (info) => <span className="font-bold text-[15px]">{info.getValue()}</span>,
+    }),
+    ...(isPersonal
+      ? []
+      : [
+          columnHelper.accessor('person', {
+            header: 'Persona',
+            cell: (info) => (
+              <span className="text-[13px] text-[var(--color-text-faint)]">{info.getValue()}</span>
+            ),
+          }),
+        ]),
+    columnHelper.accessor((row) => getExpenseTotal(row), {
+      id: 'amount',
+      header: 'Monto',
+      cell: (info) => (
+        <div className="flex items-center gap-2">
+          <span className="font-extrabold text-[16px] text-[var(--color-teal-dark)]">
+            {formatCOP(info.getValue())}
           </span>
-        )}
-      </div>
-    ),
-  }),
-  columnHelper.accessor('date', {
-    header: 'Fecha',
-    cell: (info) => (
-      <span className="text-[12px] text-[var(--color-text-faint)]">{info.getValue()}</span>
-    ),
-  }),
-  columnHelper.accessor('status', {
-    header: 'Estado',
-    cell: ({ row, table }) => {
-      const { onToggle } = table.options.meta;
-      const isPaid = row.original.status === 'paid';
-      return (
-        <button
-          type="button"
-          onClick={() => onToggle(row.original.id)}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-semibold transition-all ${
-            isPaid
-              ? 'bg-[rgba(5,150,105,0.12)] border border-[rgba(5,150,105,0.25)] text-[#059669]'
-              : 'bg-[rgba(251,191,36,0.12)] border border-[rgba(251,191,36,0.25)] text-[#D97706]'
-          }`}
-        >
-          {isPaid ? <CheckCircle size={14} /> : <Clock size={14} />}
-          {isPaid ? 'Pagado' : 'Pendiente'}
-        </button>
-      );
-    },
-  }),
-  columnHelper.display({
-    id: 'actions',
-    header: '',
-    cell: ({ row, table }) => {
-      const { onDelete, onEdit } = table.options.meta;
-      return (
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => onEdit(row.original)}
-            className="bg-[rgba(20,184,166,0.08)] border border-[rgba(20,184,166,0.25)] text-[var(--color-teal-dark)] rounded-lg p-[6px_8px] flex items-center"
-          >
-            <Pencil size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={() => onDelete(row.original.id)}
-            className="bg-[rgba(220,38,38,0.08)] border border-[rgba(220,38,38,0.2)] text-[#DC2626] rounded-lg p-[6px_8px] flex items-center"
-          >
-            <Trash2 size={14} />
-          </button>
+          {info.row.original.items && info.row.original.items.length > 1 && (
+            <span className="text-[11px] text-[var(--color-text-muted)]">
+              ({info.row.original.items.length} ítems)
+            </span>
+          )}
         </div>
-      );
-    },
-  }),
-];
+      ),
+    }),
+    columnHelper.accessor('date', {
+      header: 'Fecha',
+      cell: (info) => (
+        <span className="text-[12px] text-[var(--color-text-faint)]">{info.getValue()}</span>
+      ),
+    }),
+    columnHelper.accessor('status', {
+      header: 'Estado',
+      cell: ({ row, table }) => {
+        const { onToggle } = table.options.meta;
+        const isPaid = row.original.status === 'paid';
+        return (
+          <button
+            type="button"
+            onClick={() => onToggle(row.original.id)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[13px] font-semibold transition-all ${
+              isPaid
+                ? 'bg-[rgba(5,150,105,0.12)] border border-[rgba(5,150,105,0.25)] text-[#059669]'
+                : 'bg-[rgba(251,191,36,0.12)] border border-[rgba(251,191,36,0.25)] text-[#D97706]'
+            }`}
+          >
+            {isPaid ? <CheckCircle size={14} /> : <Clock size={14} />}
+            {isPaid ? 'Pagado' : 'Pendiente'}
+          </button>
+        );
+      },
+    }),
+    columnHelper.display({
+      id: 'actions',
+      header: '',
+      cell: ({ row, table }) => {
+        const { onDelete, onEdit } = table.options.meta;
+        return (
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => onEdit(row.original)}
+              className="bg-[rgba(20,184,166,0.08)] border border-[rgba(20,184,166,0.25)] text-[var(--color-teal-dark)] rounded-lg p-[6px_8px] flex items-center"
+            >
+              <Pencil size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(row.original.id)}
+              className="bg-[rgba(220,38,38,0.08)] border border-[rgba(220,38,38,0.2)] text-[#DC2626] rounded-lg p-[6px_8px] flex items-center"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        );
+      },
+    }),
+  ];
+}
 
-export default function ExpenseTable({ expenses, onToggle, onDelete, onEdit }) {
+export default function ExpenseTable({ expenses, projectType, onToggle, onDelete, onEdit }) {
+  const isPersonal = projectType === 'personal';
+  const columns = buildColumns(isPersonal);
   const [sorting, setSorting] = useState([]);
   const [expanded, setExpanded] = useState({});
 
@@ -142,7 +150,7 @@ export default function ExpenseTable({ expenses, onToggle, onDelete, onEdit }) {
   });
 
   return (
-    <div className="overflow-x-auto hidden md:block">
+    <div className="overflow-x-auto">
       <table className="w-full text-left">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
@@ -184,7 +192,7 @@ export default function ExpenseTable({ expenses, onToggle, onDelete, onEdit }) {
                 </tr>
                 {isExpanded && hasItems && (
                   <tr key={`${row.id}-items`} className="bg-[var(--bg)]">
-                    <td colSpan={columns.length} className="py-1 px-2">
+                    <td colSpan={isPersonal ? 5 : 6} className="py-1 px-2">
                       <table className="w-full">
                         <tbody>
                           {items.map((item, idx) => (

--- a/src/components/PersonSummary.jsx
+++ b/src/components/PersonSummary.jsx
@@ -37,14 +37,15 @@ function Avatar({ name, className = '' }) {
   );
 }
 
-export default function PersonSummary({ expenses }) {
+export default function PersonSummary({ expenses, projectType }) {
   const [activeTab, setActiveTab] = useState('resumen');
   const [strategy, setStrategy] = useState('equal');
+  const isPersonal = projectType === 'personal';
   const people = [...new Set(expenses.map((e) => e.person))];
 
   if (people.length === 0) return null;
 
-  const summaries = people.map((person) => {
+  const _summaries = people.map((person) => {
     const personExpenses = expenses.filter((e) => e.person === person);
     const total = personExpenses.reduce((sum, e) => sum + getExpenseTotal(e), 0);
     const paid = personExpenses
@@ -83,76 +84,22 @@ export default function PersonSummary({ expenses }) {
 
   return (
     <div className="bg-[var(--card-bg)] border border-[var(--card-border)] rounded-[16px] p-5 mb-4">
-      <div className="flex items-center justify-between mb-4">
-        <Tabs value={activeTab} onChange={setActiveTab}>
-          <Tabs.Tab value="resumen" label="Resumen" />
-          <Tabs.Tab value="balance" label="Balance" />
-        </Tabs>
-        {activeTab === 'balance' && (
-          <Tabs value={strategy} onChange={setStrategy}>
-            <Tabs.Tab value="equal" label="Igual" />
-            <Tabs.Tab value="individual" label="Individual" />
+      {!isPersonal && (
+        <div className="flex items-center justify-between mb-4">
+          <Tabs value={activeTab} onChange={setActiveTab}>
+            <Tabs.Tab value="resumen" label="Resumen" />
+            <Tabs.Tab value="balance" label="Balance" />
           </Tabs>
-        )}
-      </div>
-
-      {activeTab === 'resumen' && (
-        <>
-          <div className="flex justify-between items-center mb-4 pb-3 border-b border-[var(--card-border)]">
-            <span className="text-[13px] text-[var(--color-text-muted)]">Total gastado</span>
-            <span className="font-bold text-[15px] text-[var(--color-teal-dark)]">
-              {formatCOP(totalPaid)}
-            </span>
-          </div>
-
-          <div className="space-y-3">
-            {summaries.map((s) => (
-              <div
-                key={s.name}
-                className="flex flex-wrap items-center gap-x-4 gap-y-2 py-3 border-b border-[var(--stat-border)] last:border-b-0"
-              >
-                <Avatar name={s.name} />
-
-                <div className="flex-1 min-w-0">
-                  <p className="font-bold text-[15px] text-[var(--color-text)] truncate">
-                    {s.name}
-                  </p>
-                  <p className="text-[12px] text-[var(--color-text-faint)]">
-                    {s.count} gasto{s.count !== 1 ? 's' : ''}
-                  </p>
-                </div>
-
-                <div className="flex items-center gap-x-4 gap-y-1 sm:gap-6 flex-wrap sm:flex-nowrap">
-                  <div className="text-right min-w-[70px]">
-                    <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
-                      Total
-                    </p>
-                    <p className="text-[14px] font-semibold text-[var(--color-teal-dark)]">
-                      {formatCOP(s.total)}
-                    </p>
-                  </div>
-                  <div className="text-right min-w-[70px]">
-                    <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
-                      Pagado
-                    </p>
-                    <p className="text-[14px] font-semibold text-[#059669]">{formatCOP(s.paid)}</p>
-                  </div>
-                  <div className="text-right min-w-[70px]">
-                    <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
-                      Pendiente
-                    </p>
-                    <p className="text-[14px] font-semibold text-[#D97706]">
-                      {formatCOP(s.pending)}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </>
+          {activeTab === 'balance' && (
+            <Tabs value={strategy} onChange={setStrategy}>
+              <Tabs.Tab value="equal" label="Igual" />
+              <Tabs.Tab value="individual" label="Individual" />
+            </Tabs>
+          )}
+        </div>
       )}
 
-      {activeTab === 'balance' && (
+      {isPersonal ? (
         <>
           <div className="flex justify-between items-center mb-4 pb-3 border-b border-[var(--card-border)]">
             <span className="text-[13px] text-[var(--color-text-muted)]">Total gastado</span>
@@ -161,52 +108,150 @@ export default function PersonSummary({ expenses }) {
             </span>
           </div>
 
-          <div className="space-y-3">
-            {people.map((person) => {
-              const balance =
-                strategy === 'equal' ? equalBalances[person] : individualBalances[person];
-              const isPositive = balance >= 0;
-              return (
-                <div
-                  key={person}
-                  className="flex items-center gap-4 py-3 border-b border-[var(--stat-border)] last:border-b-0"
-                >
-                  <Avatar name={person} />
-                  <div className="flex-1 min-w-0">
-                    <p className="font-bold text-[15px] text-[var(--color-text)] truncate">
-                      {person}
-                    </p>
-                  </div>
-                  <span
-                    className={`text-[14px] font-bold ${
-                      isPositive ? 'text-[#059669]' : 'text-[#DC2626]'
-                    }`}
-                  >
-                    {isPositive ? '+' : ''}
-                    {formatCOP(balance)}
-                  </span>
-                </div>
-              );
-            })}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-[rgba(5,150,105,0.08)] border border-[rgba(5,150,105,0.2)] rounded-xl p-4 text-center">
+              <p className="text-[12px] text-[#059669] font-semibold uppercase tracking-wide mb-1">
+                Pagado
+              </p>
+              <p className="text-[18px] font-bold text-[#059669]">{formatCOP(totalPaid)}</p>
+            </div>
+            <div className="bg-[rgba(251,191,36,0.08)] border border-[rgba(251,191,36,0.2)] rounded-xl p-4 text-center">
+              <p className="text-[12px] text-[#D97706] font-semibold uppercase tracking-wide mb-1">
+                Pendiente
+              </p>
+              <p className="text-[18px] font-bold text-[#D97706]">
+                {formatCOP(
+                  expenses
+                    .filter((e) => e.status === 'pending')
+                    .reduce((sum, e) => sum + getExpenseTotal(e), 0)
+                )}
+              </p>
+            </div>
           </div>
 
-          {people.length > 1 && strategy === 'equal' && (
-            <div className="mt-4 pt-4 border-t border-[var(--card-border)] text-center">
-              <p className="text-[12px] text-[var(--color-text-faint)]">
-                Por persona:{' '}
-                <span className="font-semibold text-[var(--color-teal)]">
-                  {formatCOP(perPerson)}
+          <div className="mt-4 pt-4 border-t border-[var(--card-border)] text-center">
+            <p className="text-[12px] text-[var(--color-text-faint)]">
+              {expenses.length} gasto{expenses.length !== 1 ? 's' : ''} en total
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          {activeTab === 'resumen' && (
+            <>
+              <div className="flex justify-between items-center mb-4 pb-3 border-b border-[var(--card-border)]">
+                <span className="text-[13px] text-[var(--color-text-muted)]">Total gastado</span>
+                <span className="font-bold text-[15px] text-[var(--color-teal-dark)]">
+                  {formatCOP(totalPaid)}
                 </span>
-              </p>
-            </div>
+              </div>
+
+              <div className="space-y-3">
+                {_summaries.map((s) => (
+                  <div
+                    key={s.name}
+                    className="flex flex-wrap items-center gap-x-4 gap-y-2 py-3 border-b border-[var(--stat-border)] last:border-b-0"
+                  >
+                    <Avatar name={s.name} />
+
+                    <div className="flex-1 min-w-0">
+                      <p className="font-bold text-[15px] text-[var(--color-text)] truncate">
+                        {s.name}
+                      </p>
+                      <p className="text-[12px] text-[var(--color-text-faint)]">
+                        {s.count} gasto{s.count !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-x-4 gap-y-1 sm:gap-6 flex-wrap sm:flex-nowrap">
+                      <div className="text-right min-w-[70px]">
+                        <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
+                          Total
+                        </p>
+                        <p className="text-[14px] font-semibold text-[var(--color-teal-dark)]">
+                          {formatCOP(s.total)}
+                        </p>
+                      </div>
+                      <div className="text-right min-w-[70px]">
+                        <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
+                          Pagado
+                        </p>
+                        <p className="text-[14px] font-semibold text-[#059669]">
+                          {formatCOP(s.paid)}
+                        </p>
+                      </div>
+                      <div className="text-right min-w-[70px]">
+                        <p className="text-[10px] text-[var(--color-text-faint)] uppercase tracking-wide">
+                          Pendiente
+                        </p>
+                        <p className="text-[14px] font-semibold text-[#D97706]">
+                          {formatCOP(s.pending)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
           )}
 
-          {people.length > 1 && strategy === 'individual' && (
-            <div className="mt-4 pt-4 border-t border-[var(--card-border)] text-center">
-              <p className="text-[12px] text-[var(--color-text-faint)]">
-                Cada persona debe lo que gastó en sus propios gastos
-              </p>
-            </div>
+          {activeTab === 'balance' && (
+            <>
+              <div className="flex justify-between items-center mb-4 pb-3 border-b border-[var(--card-border)]">
+                <span className="text-[13px] text-[var(--color-text-muted)]">Total gastado</span>
+                <span className="font-bold text-[15px] text-[var(--color-teal-dark)]">
+                  {formatCOP(totalPaid)}
+                </span>
+              </div>
+
+              <div className="space-y-3">
+                {people.map((person) => {
+                  const balance =
+                    strategy === 'equal' ? equalBalances[person] : individualBalances[person];
+                  const isPositive = balance >= 0;
+                  return (
+                    <div
+                      key={person}
+                      className="flex items-center gap-4 py-3 border-b border-[var(--stat-border)] last:border-b-0"
+                    >
+                      <Avatar name={person} />
+                      <div className="flex-1 min-w-0">
+                        <p className="font-bold text-[15px] text-[var(--color-text)] truncate">
+                          {person}
+                        </p>
+                      </div>
+                      <span
+                        className={`text-[14px] font-bold ${
+                          isPositive ? 'text-[#059669]' : 'text-[#DC2626]'
+                        }`}
+                      >
+                        {isPositive ? '+' : ''}
+                        {formatCOP(balance)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {people.length > 1 && strategy === 'equal' && (
+                <div className="mt-4 pt-4 border-t border-[var(--card-border)] text-center">
+                  <p className="text-[12px] text-[var(--color-text-faint)]">
+                    Por persona:{' '}
+                    <span className="font-semibold text-[var(--color-teal)]">
+                      {formatCOP(perPerson)}
+                    </span>
+                  </p>
+                </div>
+              )}
+
+              {people.length > 1 && strategy === 'individual' && (
+                <div className="mt-4 pt-4 border-t border-[var(--card-border)] text-center">
+                  <p className="text-[12px] text-[var(--color-text-faint)]">
+                    Cada persona debe lo que gastó en sus propios gastos
+                  </p>
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,10 @@
 export const STORAGE_KEY = 'moni_v1';
 
+export const PROJECT_TYPES = {
+  SHARED: 'shared',
+  PERSONAL: 'personal',
+};
+
 export const formatCOP = (n) => `$${n.toLocaleString('es-CO')}`;
 
 export function haptic(ms = 15) {


### PR DESCRIPTION
## Summary
- Add project type (shared/personal) to data model
- Personal projects hide person field and balance calculations
- New Stats tab for personal projects with paid/pending breakdown
- Personal badge indicator in project header
- Hide Persona column in expense list/table for personal projects

## Changes
- **src/utils.js**: Add `PROJECT_TYPES` constant
- **src/App.jsx**: Project type selector in create modal, pass projectType to child components
- **src/components/CreateExpenseSheet.jsx**: Hide person field for personal projects
- **src/components/PersonSummary.jsx**: Stats view without tabs for personal projects
- **src/components/ExpenseTable.jsx**: Conditionally hide Persona column
- **src/components/ExpenseCard.jsx**: Hide person name for personal projects
- **src/components/ExpenseList.jsx**: Pass projectType down to children